### PR TITLE
fix: update setMonth and setYear to the new url

### DIFF
--- a/library.js
+++ b/library.js
@@ -39,11 +39,11 @@ const getSlots = (mode) => {
 };
 
 const setMonth = () => {
-  workMonth = tabURL.split("clock-in/")[1].split("/")[1];
+  workMonth = tabURL.split("clock-in/")[1].split("/")[2];
 };
 
 const setYear = () => {
-  workYear = tabURL.split("clock-in/")[1].split("/")[0];
+  workYear = tabURL.split("clock-in/")[1].split("/")[1];
 };
 
 const getData = async (mode, tab) => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Refactorial",
-    "version": "2.1",
+    "version": "2.2",
     "description": "Save time filling automatically your work report.",
     "manifest_version": 3,
     "action": {


### PR DESCRIPTION
Factorial has updated their clock-in URL with a new filter by month or by week. Before, it shows something like:

`https://app.factorialhr.com/attendance/clock-in/2024/12/1`

And now it adds the filter:

`https://app.factorialhr.com/attendance/clock-in/monthly/2024/12/1`

I have fixed it by just getting the next element of the url array.

This should fix the issue https://github.com/abelbendana/refactorial/issues/6